### PR TITLE
ci: update workflow trigger to run on every push

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -2,8 +2,6 @@ name: build-cn10k
 
 on:
   push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
   schedule:
     - cron: "0 0 * * 1"
   pull_request:


### PR DESCRIPTION
Modified the GitHub Actions workflow to trigger on every push rather than only on tag pushes.