### PR TITLE
ci: fix cache actions in workflow

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           echo 'ccache=ccache-'$(date -u +%Y-m%M) >> $GITHUB_OUTPUT
       - name: Retrieve ccache cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ~/.ccache
           key: ${{ steps.get_ref_keys.outputs.ccache }}-${{ github.ref }}
@@ -44,7 +44,6 @@ jobs:
       - name: Build OCTEON-EP and generate package
         id: build
         run: |
-            mkdir -p ~/.ccache
             BASE_DIR=${PWD}
             sudo apt-get update -q -y
             sudo apt-get install -y build-essential gcc meson ccache git doxygen apt-utils dialog
@@ -59,7 +58,6 @@ jobs:
             export CFLAGS="-DUSE_PEM_AND_DPI_PF=1"
             export INSTALL_PATH=$PWD/install/usr
             cd target/libs/octep_cp_lib
-            echo "cache_dir = ~/.ccache" > ~/.ccache/ccache.conf
             ccache -p
             make install
             cd -
@@ -80,6 +78,7 @@ jobs:
             echo "Description: Octeon-ep agent for Marvell Octeon 10" >> DEBIAN/control
             rm -rf debian
             cd -
+            rm -rf "${PWD}/install/~" "${PWD}/install/home"
             mv "${PWD}/install" "${PWD}/oct-ep-target-cn10k${PKG_POSTFIX}_${PKG_VERSION_NAME}_arm64"
             dpkg --build "${PWD}/oct-ep-target-cn10k${PKG_POSTFIX}_${PKG_VERSION_NAME}_arm64"
             cp "${PWD}/oct-ep-target-cn10k${PKG_POSTFIX}_${PKG_VERSION_NAME}_arm64.deb" ${BASE_DIR}/artifacts/.


### PR DESCRIPTION
- Update actions/cache to v4.2.3.
- Remove .ccache before packaging.